### PR TITLE
-support centos

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,3 +14,8 @@ default['graphite_api']['whisper'] = {
 if node['graphite_api']['whisper']['enabled'] == true
   default['graphite_api']['finders'] |= ['graphite_api.finders.whisper.WhisperFinder']
 end
+
+default['graphite_api']['gunicorn_path'] = '/usr/local/bin/gunicorn'
+default['graphite_api']['gunicorn_workers'] = 1
+default['graphite_api']['bind_address'] = '0.0.0.0'
+default['graphite_api']['bind_port'] = 8888

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,5 @@ supports 'debian'
 supports 'ubuntu'
 
 depends 'build-essential'
-depends 'python'
 depends 'packagecloud'
 depends 'python'

--- a/recipes/install_with_pip.rb
+++ b/recipes/install_with_pip.rb
@@ -15,8 +15,15 @@ file node['graphite_api']['search_index'] do
   action :create_if_missing
 end
 
-%w(libcairo2-dev libffi-dev).each do |pkg|
-  package pkg
+case node['platform_family']
+when 'debian'
+  %w(libcairo2-dev libffi-dev).each do |pkg|
+    package pkg
+  end
+when 'rhel'
+  %w(cairo-devel libffi-devel).each do |pkg|
+    package pkg
+  end
 end
 
 %w(gunicorn graphite-api).each do |pkg|

--- a/templates/default/graphite-api-init.erb
+++ b/templates/default/graphite-api-init.erb
@@ -12,7 +12,7 @@
 PIDFILE=/var/run/graphite-api.pid
 LOGFILE=/var/log/graphite-api.log
 
-SCRIPT="/usr/local/bin/gunicorn graphite_api.app:app -b 0.0.0.0:8888 --access-logfile \"$LOGFILE\" --error-logfile \"$LOGFILE\""
+SCRIPT="<%= node['graphite_api']['gunicorn_path'] %> graphite_api.app:app -b <%= node['graphite_api']['bind_address'] %>:<%= node['graphite_api']['bind_port'] %> --access-logfile \"$LOGFILE\" --error-logfile \"$LOGFILE\" --workers <%= node['graphite_api']['gunicorn_workers'] %>"
 
 RUNAS=root
 


### PR DESCRIPTION
- Add CentOS support (Tested on CentOS 7)
- Make Graphite API address and port configurable
- Make Gunicorn path configurable
